### PR TITLE
feat: 로그인 API 구현

### DIFF
--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -1,0 +1,33 @@
+from rest_framework import serializers
+from .models import User, UserProfile, UserHealthProfile, UserEnvironment
+
+
+class SignupSerializer(serializers.ModelSerializer):
+    password = serializers.CharField(write_only=True, min_length=8)
+
+    class Meta:
+        model = User
+        fields = ["id", "email", "password", "nickname"]
+
+    def validate_email(self, value):
+        if User.objects.filter(email=value).exists():
+            raise serializers.ValidationError("이미 사용 중인 이메일입니다.")
+        return value
+
+    def create(self, validated_data):
+        email = validated_data["email"]
+        password = validated_data["password"]
+        nickname = validated_data["nickname"]
+
+        user = User.objects.create_user(
+            username=email,
+            email=email,
+            password=password,
+            nickname=nickname
+        )
+
+        UserProfile.objects.create(user=user)
+        UserHealthProfile.objects.create(user=user)
+        UserEnvironment.objects.create(user=user)
+
+        return user

--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -1,6 +1,6 @@
+from django.contrib.auth import authenticate
 from rest_framework import serializers
 from .models import User, UserProfile, UserHealthProfile, UserEnvironment
-
 
 class SignupSerializer(serializers.ModelSerializer):
     password = serializers.CharField(write_only=True, min_length=8)
@@ -37,3 +37,22 @@ class SignupSerializer(serializers.ModelSerializer):
         UserEnvironment.objects.create(user=user)
 
         return user
+
+class LoginSerializer(serializers.Serializer):
+    email = serializers.EmailField()
+    password = serializers.CharField(write_only=True)
+
+    def validate(self, data):
+        email = data["email"]
+        password = data["password"]
+
+        user = authenticate(
+            username=email,
+            password=password
+        )
+
+        if user is None:
+            raise serializers.ValidationError("이메일 또는 비밀번호가 일치하지 않습니다.")
+
+        data["user"] = user
+        return data

--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -4,20 +4,26 @@ from .models import User, UserProfile, UserHealthProfile, UserEnvironment
 
 class SignupSerializer(serializers.ModelSerializer):
     password = serializers.CharField(write_only=True, min_length=8)
+    password_confirm = serializers.CharField(write_only=True, min_length=8)
 
     class Meta:
         model = User
-        fields = ["id", "email", "password", "nickname"]
+        fields = ["id", "email", "password", "password_confirm", "nickname"]
 
-    def validate_email(self, value):
-        if User.objects.filter(email=value).exists():
-            raise serializers.ValidationError("이미 사용 중인 이메일입니다.")
-        return value
+    def validate(self, data):
+        if data["password"] != data["password_confirm"]:
+            raise serializers.ValidationError({
+                "password_confirm": "비밀번호가 일치하지 않습니다."
+            })
+        return data
 
     def create(self, validated_data):
         email = validated_data["email"]
         password = validated_data["password"]
         nickname = validated_data["nickname"]
+
+        # password_confirm은 User 모델에 저장하는 값이 아니므로 제거
+        validated_data.pop("password_confirm")
 
         user = User.objects.create_user(
             username=email,

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from .views import SignupView
+
+urlpatterns = [
+    path("signup/", SignupView.as_view(), name="signup"),
+]

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
-from .views import SignupView
+from .views import SignupView, LoginView
 
 urlpatterns = [
     path("signup/", SignupView.as_view(), name="signup"),
+    path("login/", LoginView.as_view(), name="login"),
 ]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -2,11 +2,22 @@ from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from .models import User
 from .serializers import SignupSerializer
 
 
 class SignupView(APIView):
     def post(self, request):
+        email = request.data.get("email")
+
+        if User.objects.filter(email=email).exists():
+            return Response(
+                {
+                    "email": ["이미 사용 중인 이메일입니다."]
+                },
+                status=status.HTTP_409_CONFLICT
+            )
+
         serializer = SignupSerializer(data=request.data)
 
         if serializer.is_valid():
@@ -16,7 +27,7 @@ class SignupView(APIView):
                 {
                     "message": "회원가입이 완료되었습니다.",
                     "user": {
-                        "id": user.id,
+                        "user_id": user.id,
                         "email": user.email,
                         "nickname": user.nickname,
                     }

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,9 +1,10 @@
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from rest_framework_simplejwt.tokens import RefreshToken
 
 from .models import User
-from .serializers import SignupSerializer
+from .serializers import SignupSerializer, LoginSerializer
 
 
 class SignupView(APIView):
@@ -36,3 +37,33 @@ class SignupView(APIView):
             )
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+    
+class LoginView(APIView):
+    def post(self, request):
+        serializer = LoginSerializer(data=request.data)
+
+        if serializer.is_valid():
+            user = serializer.validated_data["user"]
+
+            refresh = RefreshToken.for_user(user)
+
+            return Response(
+                {
+                    "message": "로그인에 성공했습니다.",
+                    "access_token": str(refresh.access_token),
+                    "refresh_token": str(refresh),
+                    "user": {
+                        "user_id": user.id,
+                        "email": user.email,
+                        "nickname": user.nickname,
+                    }
+                },
+                status=status.HTTP_200_OK
+            )
+
+        return Response(
+            {
+                "detail": "이메일 또는 비밀번호가 일치하지 않습니다."
+            },
+            status=status.HTTP_401_UNAUTHORIZED
+        )

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,3 +1,27 @@
-from django.shortcuts import render
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
-# Create your views here.
+from .serializers import SignupSerializer
+
+
+class SignupView(APIView):
+    def post(self, request):
+        serializer = SignupSerializer(data=request.data)
+
+        if serializer.is_valid():
+            user = serializer.save()
+
+            return Response(
+                {
+                    "message": "회원가입이 완료되었습니다.",
+                    "user": {
+                        "id": user.id,
+                        "email": user.email,
+                        "nickname": user.nickname,
+                    }
+                },
+                status=status.HTTP_201_CREATED
+            )
+
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/config/urls.py
+++ b/config/urls.py
@@ -15,8 +15,9 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("api/v1/users/", include("accounts.urls")),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Django==5.2.6
+djangorestframework

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Django==5.2.6
 djangorestframework
+djangorestframework-simplejwt


### PR DESCRIPTION
## 작업 내용
- 로그인 API 구현
- POST /api/v1/users/login/ 경로 연결
- 이메일, 비밀번호 기반 로그인 처리
- 로그인 성공 시 access_token, refresh_token 발급
- 로그인 성공 시 user_id, email, nickname 응답
- 이메일 또는 비밀번호 불일치 시 401 Unauthorized 응답 처리

## 테스트
- 정상 로그인 시 200 OK 응답 확인
- access_token, refresh_token 응답 확인
- 잘못된 로그인 정보 입력 시 401 Unauthorized 응답 확인

## 참고
- 선행 PR: 회원가입 API PR이 먼저 merge되어야 합니다.