### PR TITLE
feat: 마이페이지 API 구현

### DIFF
--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -56,3 +56,25 @@ class LoginSerializer(serializers.Serializer):
 
         data["user"] = user
         return data
+    
+class UserProfileSerializer(serializers.Serializer):
+    profile_id = serializers.IntegerField(source="id", read_only=True)
+    user_id = serializers.IntegerField(source="user.id", read_only=True)
+    email = serializers.EmailField(source="user.email", read_only=True)
+    nickname = serializers.CharField(source="user.nickname", read_only=True)
+    cooking_level = serializers.IntegerField(read_only=True)
+    housing = serializers.CharField(read_only=True)
+    preference = serializers.SerializerMethodField()
+
+    def get_preference(self, obj):
+        if not obj.preference:
+            return []
+
+        if isinstance(obj.preference, list):
+            return obj.preference
+
+        return [
+            item.strip()
+            for item in obj.preference.split(",")
+            if item.strip()
+        ]

--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -78,3 +78,12 @@ class UserProfileSerializer(serializers.Serializer):
             for item in obj.preference.split(",")
             if item.strip()
         ]
+    
+class UserProfileUpdateSerializer(serializers.Serializer):
+    nickname = serializers.CharField(required=False, allow_blank=True)
+    cooking_level = serializers.IntegerField(required=False)
+    housing = serializers.CharField(required=False, allow_blank=True)
+    preference = serializers.ListField(
+        child=serializers.CharField(),
+        required=False
+    )

--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -1,0 +1,33 @@
+from rest_framework import serializers
+from .models import User, UserProfile, UserHealthProfile, UserEnvironment
+
+
+class SignupSerializer(serializers.ModelSerializer):
+    password = serializers.CharField(write_only=True, min_length=8)
+
+    class Meta:
+        model = User
+        fields = ["id", "email", "password", "nickname"]
+
+    def validate_email(self, value):
+        if User.objects.filter(email=value).exists():
+            raise serializers.ValidationError("이미 사용 중인 이메일입니다.")
+        return value
+
+    def create(self, validated_data):
+        email = validated_data["email"]
+        password = validated_data["password"]
+        nickname = validated_data["nickname"]
+
+        user = User.objects.create_user(
+            username=email,
+            email=email,
+            password=password,
+            nickname=nickname
+        )
+
+        UserProfile.objects.create(user=user)
+        UserHealthProfile.objects.create(user=user)
+        UserEnvironment.objects.create(user=user)
+
+        return user

--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -1,6 +1,6 @@
+from django.contrib.auth import authenticate
 from rest_framework import serializers
 from .models import User, UserProfile, UserHealthProfile, UserEnvironment
-
 
 class SignupSerializer(serializers.ModelSerializer):
     password = serializers.CharField(write_only=True, min_length=8)
@@ -37,3 +37,22 @@ class SignupSerializer(serializers.ModelSerializer):
         UserEnvironment.objects.create(user=user)
 
         return user
+
+class LoginSerializer(serializers.Serializer):
+    email = serializers.EmailField()
+    password = serializers.CharField(write_only=True)
+
+    def validate(self, data):
+        email = data["email"]
+        password = data["password"]
+
+        user = authenticate(
+            username=email,
+            password=password
+        )
+
+        if user is None:
+            raise serializers.ValidationError("이메일 또는 비밀번호가 일치하지 않습니다.")
+
+        data["user"] = user
+        return data

--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -4,20 +4,26 @@ from .models import User, UserProfile, UserHealthProfile, UserEnvironment
 
 class SignupSerializer(serializers.ModelSerializer):
     password = serializers.CharField(write_only=True, min_length=8)
+    password_confirm = serializers.CharField(write_only=True, min_length=8)
 
     class Meta:
         model = User
-        fields = ["id", "email", "password", "nickname"]
+        fields = ["id", "email", "password", "password_confirm", "nickname"]
 
-    def validate_email(self, value):
-        if User.objects.filter(email=value).exists():
-            raise serializers.ValidationError("이미 사용 중인 이메일입니다.")
-        return value
+    def validate(self, data):
+        if data["password"] != data["password_confirm"]:
+            raise serializers.ValidationError({
+                "password_confirm": "비밀번호가 일치하지 않습니다."
+            })
+        return data
 
     def create(self, validated_data):
         email = validated_data["email"]
         password = validated_data["password"]
         nickname = validated_data["nickname"]
+
+        # password_confirm은 User 모델에 저장하는 값이 아니므로 제거
+        validated_data.pop("password_confirm")
 
         user = User.objects.create_user(
             username=email,

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from .views import SignupView
+
+urlpatterns = [
+    path("signup/", SignupView.as_view(), name="signup"),
+]

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
-from .views import SignupView
+from .views import SignupView, LoginView
 
 urlpatterns = [
     path("signup/", SignupView.as_view(), name="signup"),
+    path("login/", LoginView.as_view(), name="login"),
 ]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -2,11 +2,22 @@ from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from .models import User
 from .serializers import SignupSerializer
 
 
 class SignupView(APIView):
     def post(self, request):
+        email = request.data.get("email")
+
+        if User.objects.filter(email=email).exists():
+            return Response(
+                {
+                    "email": ["이미 사용 중인 이메일입니다."]
+                },
+                status=status.HTTP_409_CONFLICT
+            )
+
         serializer = SignupSerializer(data=request.data)
 
         if serializer.is_valid():
@@ -16,7 +27,7 @@ class SignupView(APIView):
                 {
                     "message": "회원가입이 완료되었습니다.",
                     "user": {
-                        "id": user.id,
+                        "user_id": user.id,
                         "email": user.email,
                         "nickname": user.nickname,
                     }

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,9 +1,10 @@
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from rest_framework_simplejwt.tokens import RefreshToken
 
 from .models import User
-from .serializers import SignupSerializer
+from .serializers import SignupSerializer, LoginSerializer
 
 
 class SignupView(APIView):
@@ -36,3 +37,33 @@ class SignupView(APIView):
             )
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+    
+class LoginView(APIView):
+    def post(self, request):
+        serializer = LoginSerializer(data=request.data)
+
+        if serializer.is_valid():
+            user = serializer.validated_data["user"]
+
+            refresh = RefreshToken.for_user(user)
+
+            return Response(
+                {
+                    "message": "로그인에 성공했습니다.",
+                    "access_token": str(refresh.access_token),
+                    "refresh_token": str(refresh),
+                    "user": {
+                        "user_id": user.id,
+                        "email": user.email,
+                        "nickname": user.nickname,
+                    }
+                },
+                status=status.HTTP_200_OK
+            )
+
+        return Response(
+            {
+                "detail": "이메일 또는 비밀번호가 일치하지 않습니다."
+            },
+            status=status.HTTP_401_UNAUTHORIZED
+        )

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -6,7 +6,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework_simplejwt.authentication import JWTAuthentication
 
 from .models import User, UserProfile
-from .serializers import SignupSerializer, LoginSerializer, UserProfileSerializer
+from .serializers import SignupSerializer, LoginSerializer, UserProfileSerializer, UserProfileUpdateSerializer
 
 class SignupView(APIView):
     def post(self, request):
@@ -86,3 +86,56 @@ class UserProfileView(APIView):
 
         serializer = UserProfileSerializer(profile)
         return Response(serializer.data, status=status.HTTP_200_OK)
+
+    def patch(self, request):
+        try:
+            profile = UserProfile.objects.get(user=request.user)
+        except UserProfile.DoesNotExist:
+            return Response(
+                {
+                    "detail": "프로필이 존재하지 않습니다."
+                },
+                status=status.HTTP_404_NOT_FOUND
+            )
+
+        serializer = UserProfileUpdateSerializer(data=request.data)
+
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        data = serializer.validated_data
+        user = request.user
+
+        if "nickname" in data:
+            user.nickname = data["nickname"]
+            user.save(update_fields=["nickname"])
+
+        if "cooking_level" in data:
+            profile.cooking_level = data["cooking_level"]
+
+        if "housing" in data:
+            profile.housing = data["housing"]
+
+        if "preference" in data:
+            profile.preference = ",".join(data["preference"])
+
+        profile.save()
+
+        return Response(
+            {
+                "message": "마이페이지 정보가 수정되었습니다.",
+                "profile": {
+                    "profile_id": profile.id,
+                    "user_id": user.id,
+                    "nickname": user.nickname,
+                    "cooking_level": profile.cooking_level,
+                    "housing": profile.housing,
+                    "preference": [
+                        item.strip()
+                        for item in profile.preference.split(",")
+                        if item.strip()
+                    ] if profile.preference else []
+                }
+            },
+            status=status.HTTP_200_OK
+        )

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -2,10 +2,11 @@ from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework_simplejwt.tokens import RefreshToken
+from rest_framework.permissions import IsAuthenticated
+from rest_framework_simplejwt.authentication import JWTAuthentication
 
-from .models import User
-from .serializers import SignupSerializer, LoginSerializer
-
+from .models import User, UserProfile
+from .serializers import SignupSerializer, LoginSerializer, UserProfileSerializer
 
 class SignupView(APIView):
     def post(self, request):
@@ -67,3 +68,21 @@ class LoginView(APIView):
             },
             status=status.HTTP_401_UNAUTHORIZED
         )
+    
+class UserProfileView(APIView):
+    authentication_classes = [JWTAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        try:
+            profile = UserProfile.objects.get(user=request.user)
+        except UserProfile.DoesNotExist:
+            return Response(
+                {
+                    "detail": "프로필이 존재하지 않습니다."
+                },
+                status=status.HTTP_404_NOT_FOUND
+            )
+
+        serializer = UserProfileSerializer(profile)
+        return Response(serializer.data, status=status.HTTP_200_OK)

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,3 +1,27 @@
-from django.shortcuts import render
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
-# Create your views here.
+from .serializers import SignupSerializer
+
+
+class SignupView(APIView):
+    def post(self, request):
+        serializer = SignupSerializer(data=request.data)
+
+        if serializer.is_valid():
+            user = serializer.save()
+
+            return Response(
+                {
+                    "message": "회원가입이 완료되었습니다.",
+                    "user": {
+                        "id": user.id,
+                        "email": user.email,
+                        "nickname": user.nickname,
+                    }
+                },
+                status=status.HTTP_201_CREATED
+            )
+
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/config/urls.py
+++ b/config/urls.py
@@ -15,8 +15,9 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("api/v1/users/", include("accounts.urls")),
 ]

--- a/config/urls.py
+++ b/config/urls.py
@@ -16,8 +16,10 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
+from accounts.views import UserProfileView
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("api/v1/users/", include("accounts.urls")),
+    path("api/v1/user-profiles/", UserProfileView.as_view(), name="user-profiles"),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Django==5.2.6
+djangorestframework

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Django==5.2.6
 djangorestframework
+djangorestframework-simplejwt


### PR DESCRIPTION
## 작업 내용
- 마이페이지 조회 API 구현
- GET /api/v1/user-profiles/ 경로 연결
- JWT 인증 적용
- 로그인한 사용자의 profile_id, user_id, email, nickname, cooking_level, housing, preference 조회
- 마이페이지 수정 API 구현
- PATCH /api/v1/user-profiles/ 요청 처리
- 닉네임, 요리 실력, 주거환경, 선호 음식 수정 처리

## 테스트
- access_token 포함 시 마이페이지 조회 성공 확인
- 마이페이지 수정 후 GET 재조회로 변경값 반영 확인
- nickname, cooking_level, housing, preference 수정 확인
- 토큰 없이 요청 시 인증 실패 확인

## 참고
- 선행 PR: 회원가입 API PR과 로그인 API PR이 먼저 merge되어야 합니다.